### PR TITLE
Add secondary command functionality

### DIFF
--- a/front-end/Nova/nova-core/abstractPlugin.ts
+++ b/front-end/Nova/nova-core/abstractPlugin.ts
@@ -4,7 +4,11 @@ export default abstract class NovaPlugin {
 
     abstract execute(command: string): string;
 
-    abstract executeSecondaryCommnand(command: string): string;
+    executeSecondaryCommnand(command: string): string | undefined {
+        // Default behavior: return undefined if plugin does not support secondary commands
+        // OR secondary command not recognized
+        return undefined;
+    };
 
     requestHistory(): string[] {
         return [];

--- a/front-end/Nova/nova-core/plugins/HelloWorldPlugin.ts
+++ b/front-end/Nova/nova-core/plugins/HelloWorldPlugin.ts
@@ -10,8 +10,8 @@ export default class HelloWorldPlugin extends NovaPlugin {
         return 'Hello! My name is Nova.';
     }
 
-    executeSecondaryCommnand(command: string): string {
-        return 'To teach me more fun things to do, go to the plugin store.';
+    executeSecondaryCommnand(command: string): string | undefined {
+        return command == 'nice to meet you' ? 'To teach me more fun things to do, go to the plugin store.': undefined;
     }
 
 }

--- a/front-end/Nova/nova-core/tests/core.test.ts
+++ b/front-end/Nova/nova-core/tests/core.test.ts
@@ -8,6 +8,8 @@ beforeEach(() => {
     return core;
 });
 
+//Syntax tree
+
 test('Syntax Tree add', () => {
     expect(core.syntaxTree.root['hello']['plugin'] instanceof HelloWorldPlugin).toBe(true);
 });
@@ -15,6 +17,8 @@ test('Syntax Tree add', () => {
 test('Syntax Tree match', () => {
     expect(core.querySyntaxTree('hello') instanceof HelloWorldPlugin).toBe(true);
 });
+
+// Keyword recognition
 
 test('Prevent keyword overwrite', () => {
     expect(() => {
@@ -28,4 +32,15 @@ test('Single word keyord recognition', () => {
 
 test('Multi-word keyord recognition', () => {
     expect(core.invoke('Hello World')).toBe('Hello! My name is Nova.');
+});
+
+// Secondary Command functionality
+
+test('Secondary command recognition', () => {
+    core.invoke('Hello');
+    expect(core.invoke('Nice to meet you')).toBe('To teach me more fun things to do, go to the plugin store.');
+});
+
+test('Command not found', () => {
+    expect(core.invoke('adfgartha')).toBe('I\'m sorry, I don\'t understand.');
 });


### PR DESCRIPTION
Adds conditional logic to support handling of command as a secondary command of last used plugin IF does not fit keyword of a registered plugin.  If not recognized as secondary command, defaults to commandNotRecognized